### PR TITLE
Add google-site-verification meta tag

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -9,6 +9,7 @@
 
 {% block head %}
 <link href="/stylesheets/application.css" media="all" rel="stylesheet" type="text/css">
+<meta name="google-site-verification" content="JYBW4MAJKPKUxecfLzCNG897toSCmnNiUq7gTCjvsnQ" />
 <meta property="og:title" content="{{ title }}">
 {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
 <meta name="robots" content="noindex nofollow">


### PR DESCRIPTION
We have a Big Red Warning for reasons nobody knows

<img width="687" alt="Screenshot 2023-03-14 at 17 20 57" src="https://user-images.githubusercontent.com/642279/225097159-751ec34c-efa4-4092-acd9-7d918d5c7561.png">

https://ukgovernmentdfe.slack.com/archives/C030N70UETH/p1677837252796999