### PR TITLE
Noindex, nofollow; remove GOV.UK from title

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,6 +7,7 @@ module.exports = function (eleventyConfig) {
     headingPermalinks: true,
     header: {
       productName: 'TRA Digital design history',
+      organisationName: 'Department for Education',
       search: {
         indexPath: '/search.json',
         sitemapPath: '/sitemap'

--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -1,1 +1,7 @@
 {% extends "layouts/collection.njk" %}
+
+{% block head %}
+  {{ super() }}
+  <meta name="robots" content="noindex nofollow">
+{% endblock %}
+

--- a/app/_layouts/home.njk
+++ b/app/_layouts/home.njk
@@ -3,6 +3,7 @@
 {% block head %}
   {{ super() }}
   <meta name="google-site-verification" content="JYBW4MAJKPKUxecfLzCNG897toSCmnNiUq7gTCjvsnQ" />
+  <meta name="robots" content="noindex nofollow">
 {% endblock %}
 
 {% block content %}

--- a/app/_layouts/page.njk
+++ b/app/_layouts/page.njk
@@ -2,6 +2,11 @@
 
 {% from "screenshots/macro.njk" import appScreenshots %}
 
+{% block head %}
+  {{ super() }}
+  <meta name="robots" content="noindex nofollow">
+{% endblock %}
+
 {% block content %}
   {{ appDocumentHeader({
     title: title | noOrphans

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -2,6 +2,11 @@
 
 {% from "screenshots/macro.njk" import appScreenshots %}
 
+{% block head %}
+  {{ super() }}
+  <meta name="robots" content="noindex nofollow">
+{% endblock %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/_layouts/search-index.njk
+++ b/app/_layouts/search-index.njk
@@ -1,1 +1,7 @@
 {% extends "layouts/search-index.njk" %}
+
+{% block head %}
+  {{ super() }}
+  <meta name="robots" content="noindex nofollow">
+{% endblock %}
+

--- a/app/_layouts/sitemap.njk
+++ b/app/_layouts/sitemap.njk
@@ -1,1 +1,6 @@
 {% extends "layouts/sitemap.njk" %}
+
+{% block head %}
+  {{ super() }}
+  <meta name="robots" content="noindex nofollow">
+{% endblock %}


### PR DESCRIPTION
Two small changes. Hypothesis is that GOV.UK in the title causes Google to consider this site rogue because it is not on gov.uk. I don't know a better way to make the meta tag generic for all pages without more work to hack together a common template.

https://ukgovernmentdfe.slack.com/archives/C030N70UETH/p1678820090148209?thread_ts=1677837252.796999&cid=C030N70UETH